### PR TITLE
formatting improved in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,10 @@ Credits -
 
 HTML, CSS and JavaScript by The Hong Kong University of Science and Technology Coursera.
 
-====
-
 Jon Duckett - <a href="https://github.com/Cybros/Lecture-Series-1-HTML-CSS-JS/tree/master/Other%20Resources/Duckett%20Handbooks">Duckett Handbooks</a>
-
-====
 
 Cody Lindley - <a href="https://github.com/Cybros/Lecture-Series-1-HTML-CSS-JS/tree/master/Other%20Resources/Gitbook%20Resources">Gitbook Resources</a>
 
-====
-
 <a href="https://github.com/Cybros/Lecture-Series-1-HTML-CSS-JS/tree/master/Other%20Resources/Tutorials%20Point%20Resources">Tutorials Point</a>
-
-====
 
 Marijn Haverbeke - for <a href="https://github.com/Cybros/Lecture-Series-1-HTML-CSS-JS/tree/master/Other%20Resources/Eloquent_JavaScript.pdf">Eloquent JavaScript</a>


### PR DESCRIPTION
As told by @divyanshu-rawat I removed "====" leaving one line spaces between credits.